### PR TITLE
Only override hanami server command in development mode

### DIFF
--- a/lib/hanami/reloader/cli.rb
+++ b/lib/hanami/reloader/cli.rb
@@ -36,4 +36,7 @@ CODE
 end
 
 Hanami::CLI.register "generate reloader", Hanami::Reloader::CLI::Generate
-Hanami::CLI.register "server",            Hanami::Reloader::CLI::Server
+
+if Hanami.env == "development"
+  Hanami::CLI.register "server",          Hanami::Reloader::CLI::Server
+end


### PR DESCRIPTION
This came up at work. When we wanted to switch from shotgun to hanami reloader, reloading was also enabled in production mode. While of course no one goes to a production server to change files, this probably adds unnecessary (little) overhead. I think it's ok-ish solution to have `hanami server` command overridden by this gem only in development mode.