### PR TITLE
Run bundle install after modifying Gemfile

### DIFF
--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 require "hanami/reloader/commands"
+require "hanami/cli/bundler"
+
 require "tmpdir"
 
 RSpec.describe Hanami::Reloader::Commands::Install do
   describe "#call" do
-    subject { described_class.new(fs: fs) }
+    subject { described_class.new(fs: fs, bundler: bundler) }
 
     let(:fs) { Dry::Files.new }
     let(:dir) { Dir.mktmpdir }
     let(:app) { "synth" }
     let(:app_name) { "Synth" }
+
+    let(:bundler) { instance_spy(Hanami::CLI::Bundler) }
 
     let(:arbitrary_argument) { {} }
 
@@ -45,6 +49,11 @@ RSpec.describe Hanami::Reloader::Commands::Install do
         end
       EOF
       expect(fs.read("Guardfile")).to eq(guardfile)
+    end
+
+    it "runs bundle install" do
+      subject.call(arbitrary_argument)
+      expect(bundler).to have_received(:install!)
     end
   end
 end


### PR DESCRIPTION
Without this, a newly generated hanami app will fail to run `hanami server` due to guard-puma not yet being bundled.