### PR TITLE
Convert to Zeitwerk for code loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV["CI"]
 end
 
 gem "hanami-utils", "~> 2.0.rc", require: false, git: "https://github.com/hanami/utils.git",  branch: "main"
-gem "hanami-cli",   "~> 2.0.rc", require: false, git: "https://github.com/hanami/cli.git",    branch: "zeitwerkify"
+gem "hanami-cli",   "~> 2.0.rc", require: false, git: "https://github.com/hanami/cli.git",    branch: "main"
 gem "hanami",       "~> 2.0.rc", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV["CI"]
 end
 
 gem "hanami-utils", "~> 2.0.rc", require: false, git: "https://github.com/hanami/utils.git",  branch: "main"
-gem "hanami-cli",   "~> 2.0.rc", require: false, git: "https://github.com/hanami/cli.git",    branch: "main"
+gem "hanami-cli",   "~> 2.0.rc", require: false, git: "https://github.com/hanami/cli.git",    branch: "zeitwerkify"
 gem "hanami",       "~> 2.0.rc", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git", branch: "main"

--- a/hanami-reloader.gemspec
+++ b/hanami-reloader.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "hanami-cli", "~> 2.0.rc"
+  spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 13.0"

--- a/lib/hanami-reloader.rb
+++ b/lib/hanami-reloader.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "hanami/reloader"
+require_relative "hanami/reloader"

--- a/lib/hanami/reloader.rb
+++ b/lib/hanami/reloader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "hanami/cli"
 require "zeitwerk"
 
 module Hanami
@@ -19,6 +20,10 @@ module Hanami
     end
 
     gem_loader.setup
-    require_relative "reloader/commands"
+
+    if Hanami::CLI.within_hanami_app?
+      Hanami::CLI.after "install", Commands::Install
+      Hanami::CLI.register "server", Commands::Server
+    end
   end
 end

--- a/lib/hanami/reloader.rb
+++ b/lib/hanami/reloader.rb
@@ -6,6 +6,8 @@ require "zeitwerk"
 module Hanami
   # Hanami reloader
   module Reloader
+    # @since 2.0.0
+    # @api private
     def self.gem_loader
       @gem_loader ||= Zeitwerk::Loader.new.tap do |loader|
         root = File.expand_path("..", __dir__)

--- a/lib/hanami/reloader.rb
+++ b/lib/hanami/reloader.rb
@@ -1,9 +1,24 @@
 # frozen_string_literal: true
 
+require "zeitwerk"
+
 module Hanami
   # Hanami reloader
   module Reloader
-    require_relative "reloader/version"
+    def self.gem_loader
+      @gem_loader ||= Zeitwerk::Loader.new.tap do |loader|
+        root = File.expand_path("..", __dir__)
+        loader.tag = "hanami-reloader"
+        loader.inflector = Zeitwerk::GemInflector.new("#{root}/hanami-reloader.rb")
+        loader.push_dir(root)
+        loader.ignore(
+          "#{root}/hanami-reloader.rb",
+          "#{root}/hanami/controller/version.rb"
+        )
+      end
+    end
+
+    gem_loader.setup
     require_relative "reloader/commands"
   end
 end

--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "hanami/cli"
-require "hanami/cli/command"
-require "hanami/cli/commands"
-require "hanami/cli/commands/app/server"
 
 module Hanami
   module Reloader

--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/cli"
-
 module Hanami
   module Reloader
     module Commands
@@ -90,9 +88,4 @@ module Hanami
       end
     end
   end
-end
-
-if Hanami::CLI.within_hanami_app?
-  Hanami::CLI.after "install", Hanami::Reloader::Commands::Install
-  Hanami::CLI.register "server", Hanami::Reloader::Commands::Server
 end

--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/reloader/commands"
 require "tmpdir"
 
 RSpec.describe Hanami::Reloader::Commands::Install do


### PR DESCRIPTION
This gem is tiny, but I thought we may as well use Zeitwerk across the board. Having this done now means that if we ever add more to this gem, the code loading setup is already done for us.