### PR TITLE
Fix `Guardfile` matcher

### DIFF
--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -22,6 +22,10 @@ module Hanami
 
       # Generate hanami-reloader configuration
       class Install < Hanami::CLI::Command
+        # @api private
+        # @since 2.1.0
+        MATCHER = %r{^(app|config|lib|slices)([\\/][^\\/]+)*\.(rb|erb|haml|slim)$}i
+
         desc "Generate configuration for code reloading"
 
         def initialize(fs: Dry::Files.new, bundler: CLI::Bundler.new(fs: fs), **args)
@@ -44,12 +48,7 @@ module Hanami
 
             group :#{Guardfile.group} do
               guard "puma", port: ENV.fetch("#{Hanami::Port::ENV_VAR}", #{Hanami::Port::DEFAULT}) do
-                watch(%r{config/*})
-                watch(%r{lib/*})
-                watch(%r{app/[^/]+.rb})
-                watch(%r{app/templates/.+..+..+})
-                watch(%r{slices/.+/.+.rb})
-                watch(%r{slices/.+/templates/.+..+..+})
+                watch(%r{^(app|config|lib|slices)([\\/][^\\/]+)*.(rb|erb|haml|slim)$}i)
               end
             end
           CODE

--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -24,6 +24,9 @@ module Hanami
       class Install < Hanami::CLI::Command
         # @api private
         # @since 2.1.0
+        #
+        # NOTE: Any change to this constant MUST be reflected in the `#generate_configuration` method,
+        #       by copying and pasting this regex.
         MATCHER = %r{^(app|config|lib|slices)([\\/][^\\/]+)*\.(rb|erb|haml|slim)$}i
 
         desc "Generate configuration for code reloading"

--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -46,15 +46,13 @@ module Hanami
         attr_reader :bundler
 
         def generate_configuration(path)
-          require "hanami/version"
-
           fs.write path, <<~CODE
             # frozen_string_literal: true
 
             group :#{Guardfile.group} do
               guard "puma", port: ENV.fetch("#{Hanami::Port::ENV_VAR}", #{Hanami::Port::DEFAULT}) do
                 # Edit the following regular expression for your needs.
-                # See: https://guides.hanamirb.org/v#{Hanami::Version.major_minor}/app/code-reloading/
+                # See: https://guides.hanamirb.org/app/code-reloading/
                 watch(%r{^(app|config|lib|slices)([\\/][^\\/]+)*.(rb|erb|haml|slim)$}i)
               end
             end

--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -46,11 +46,15 @@ module Hanami
         attr_reader :bundler
 
         def generate_configuration(path)
+          require "hanami/version"
+
           fs.write path, <<~CODE
             # frozen_string_literal: true
 
             group :#{Guardfile.group} do
               guard "puma", port: ENV.fetch("#{Hanami::Port::ENV_VAR}", #{Hanami::Port::DEFAULT}) do
+                # Edit the following regular expression for your needs.
+                # See: https://guides.hanamirb.org/v#{Hanami::Version.major_minor}/app/code-reloading/
                 watch(%r{^(app|config|lib|slices)([\\/][^\\/]+)*.(rb|erb|haml|slim)$}i)
               end
             end

--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -33,17 +33,14 @@ RSpec.describe Hanami::Reloader::Commands::Install do
       expect(fs.read("Gemfile")).to include(gemfile)
 
       # Guardfile
+      matcher = Hanami::Reloader::Commands::Install::MATCHER.inspect.gsub("/^", "^").gsub("$/i", "$}i").gsub('*\\.', "*.").gsub("\\\\\\", %(\\))
+      matcher = %(%r{#{matcher})
       guardfile = <<~EOF
         # frozen_string_literal: true
 
         group :server do
           guard "puma", port: ENV.fetch("HANAMI_PORT", 2300) do
-            watch(%r{config/*})
-            watch(%r{lib/*})
-            watch(%r{app/[^/]+.rb})
-            watch(%r{app/templates/.+..+..+})
-            watch(%r{slices/.+/.+.rb})
-            watch(%r{slices/.+/templates/.+..+..+})
+            watch(#{matcher})
           end
         end
       EOF

--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hanami::Reloader::Commands::Install do
         group :server do
           guard "puma", port: ENV.fetch("HANAMI_PORT", 2300) do
             # Edit the following regular expression for your needs.
-            # See: https://guides.hanamirb.org/v2.1/app/code-reloading/
+            # See: https://guides.hanamirb.org/app/code-reloading/
             watch(#{matcher})
           end
         end

--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Hanami::Reloader::Commands::Install do
 
         group :server do
           guard "puma", port: ENV.fetch("HANAMI_PORT", 2300) do
+            # Edit the following regular expression for your needs.
+            # See: https://guides.hanamirb.org/v2.1/app/code-reloading/
             watch(#{matcher})
           end
         end

--- a/spec/unit/hanami/reloader/matcher_spec.rb
+++ b/spec/unit/hanami/reloader/matcher_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "hanami/reloader/commands"
+
+RSpec.describe "Hanami::Reloader::Commands::Install::MATCHER" do
+  subject { Hanami::Reloader::Commands::Install::MATCHER }
+
+  let(:matching_paths) do
+    [
+      "app/action.rb",
+      "app/view.rb",
+      "app/actions/books/index.rb",
+      "app/actions/books/discounted/index.rb",
+      "app/views/helpers.rb",
+      "app/views/books/index.rb",
+      "app/views/books/discounted/index.rb",
+      "app/templates/books/index.html.erb",
+      "app/templates/books/discounted/index.html.erb",
+      "app/templates/layouts/app.html.erb",
+      "config/app.rb",
+      "config/puma.rb",
+      "config/routes.rb",
+      "config/settings.rb",
+      "lib/bookshelf/types.rb",
+      "slices/admin/action.rb",
+      "slices/admin/view.rb",
+      "slices/admin/actions/users/index.rb",
+      "slices/admin/actions/users/deactivated/index.rb",
+      "slices/admin/views/helpers.rb",
+      "slices/admin/views/users/index.rb",
+      "slices/admin/views/users/deactivated/index.rb",
+      "slices/admin/templates/users/index.html.slim",
+      "slices/admin/templates/users/deactivated/index.html.slim",
+      "slices/api/templates/authors/index.json.haml",
+      "slices/api/templates/authors/uprising/index.json.haml"
+    ]
+  end
+
+  let(:non_matching_paths) do
+    [
+      "Gemfile",
+      "Gemfile.lock",
+      "Guardfile",
+      "Procfile.dev",
+      "README.md",
+      "Rakefile",
+      "config.ru",
+      "app/assets/css/app.css",
+      "app/assets/js/app.js",
+      "app/assets/images/favicon.ico",
+      "slices/admin/assets/css/app.css",
+      "slices/admin/assets/js/app.js",
+      "slices/admin/assets/images/favicon.ico",
+      "log/test.log",
+      "node_modules/hanami-assets/dist/hanami-assets.js",
+      "package.json",
+      "package-lock.json",
+      "package.json",
+      "public/assets.json",
+      "public/assets/favicon.ico",
+      "spec/spec_helper.rb",
+      "spec/requests/root_spec.rb",
+      "spec/support/requests.rb",
+      "spec/support/rspec.rb",
+      "spec/actions/books/index_spec.rb",
+      "spec/actions/books/discounted/index_spec.rb",
+      "spec/views/books/index_spec.rb",
+      "spec/views/books/discounted/index_spec.rb"
+    ]
+  end
+
+  context "UNIX" do
+    it "matches the given patterns" do
+      matching_paths.each do |path|
+        expect(path).to match(subject)
+      end
+    end
+
+    it "does not matches the given patterns" do
+      non_matching_paths.each do |path|
+        expect(path).to_not match(subject)
+      end
+    end
+  end
+
+  context "Windows" do
+    it "matches the given patterns" do
+      matching_paths.each do |path|
+        expect(windows_path(path)).to match(subject)
+      end
+    end
+
+    it "does not matches the given patterns" do
+      non_matching_paths.each do |path|
+        expect(windows_path(path)).to_not match(subject)
+      end
+    end
+
+    private
+
+    def windows_path(path)
+      path.gsub("/", "\\")
+    end
+  end
+end


### PR DESCRIPTION
# Fix

I introduced the `Hanami::Reloader::Commands::Install::MATCHER` constant, which is unit-tested to assert (non)matching patterns. That constant is used in the generation of the `Guardfile`.

I manually tested this fix with https://github.com/jodosha/hanami-210-beta2-test-app
Please manually test as well.

---

Fixes https://github.com/hanami/reloader/issues/24
Fixes https://github.com/hanami/reloader/issues/25
Fixes https://github.com/hanami/reloader/issues/26