### PR TITLE
Drop support for Ruby 3.0, update README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
           - "3.3"
           - "3.2"
           - "3.1"
-          - "3.0"
     steps:
       - uses: actions/checkout@v1
       - name: Install package dependencies

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Reloader and testing support for [full-stack Hanami applications](`https://githu
 ## Status
 
 [![Gem Version](https://badge.fury.io/rb/hanami-reloader.svg)](https://badge.fury.io/rb/hanami-rspec)
-[![CI](https://github.com/hanami/reloader/workflows/ci/badge.svg?branch=main)](https://github.com/hanami/rspec/actions?query=workflow%3Aci+branch%3Amain)
+[![CI](https://github.com/hanami/reloader/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hanami/rspec/actions?query=workflow%3Aci+branch%3Amain)
 [![Depfu](https://badges.depfu.com/badges/a8545fb67cf32a2c75b6227bc0821027/overview.svg)](https://depfu.com/github/hanami/reloader?project=Bundler)
 
 ## Version
@@ -17,14 +17,12 @@ Versioning of this gem follows Reloader.
 - Home page: http://hanamirb.org
 - Mailing List: http://hanamirb.org/mailing-list
 - Bugs/Issues: https://github.com/hanami/reloader/issues
-- Support: http://stackoverflow.com/questions/tagged/hanami
 - Chat: http://chat.hanamirb.org
 
-## Rubies
-
-**Hanami::Reloader** supports Ruby (MRI) 3.0+
 
 ## Installation
+
+**Hanami::Reloader** supports Ruby (MRI) 3.1+
 
 Add this line to your application's Gemfile:
 
@@ -61,4 +59,4 @@ Everyone interacting in the `Hanami::Reloader` project's codebases, issue tracke
 
 ## Copyright
 
-Copyright © 2014 Hanami Team – Released under MIT License
+Copyright © 2014–2024 Hanami Team – Released under MIT License

--- a/hanami-reloader.gemspec
+++ b/hanami-reloader.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://hanamirb.org"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.files         = `git ls-files -- lib/* CHANGELOG.md LICENSE.md README.md hanami-reloader.gemspec`.split($INPUT_RECORD_SEPARATOR) # rubocop:disable Layout/LineLength
   spec.bindir        = "exe"


### PR DESCRIPTION
I've been doing this on the other repos directly on `main`, but I don't have write access to push to this repository so here's a PR from a personal fork.

@timriley Can you also give me write access to this repo when you merge this?