### PR TITLE
Depend on guard and guard-puma via gemspec

### DIFF
--- a/hanami-reloader.gemspec
+++ b/hanami-reloader.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["rubygems_mfa_required"] = "true"
 
+  spec.add_dependency "guard", "~> 2.19"
+  spec.add_dependency "guard-puma", "~> 0.8"
   spec.add_dependency "hanami-cli", "~> 2.2.rc"
   spec.add_dependency "zeitwerk", "~> 2.6"
 

--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -31,19 +31,15 @@ module Hanami
 
         desc "Generate configuration for code reloading"
 
-        def initialize(fs: Dry::Files.new, bundler: CLI::Bundler.new(fs: fs), **args)
-          super(fs: fs, **args)
-          @bundler = bundler
+        def initialize(fs: Dry::Files.new, **args)
+          super
         end
 
         def call(*, **)
           generate_configuration(Guardfile.default_path)
-          bundle_gems
         end
 
         private
-
-        attr_reader :bundler
 
         def generate_configuration(path)
           fs.write path, <<~CODE
@@ -57,28 +53,6 @@ module Hanami
               end
             end
           CODE
-        end
-
-        def bundle_gems
-          fs.touch("Gemfile")
-          gemfile = fs.read("Gemfile")
-
-          return if gemfile.include?("guard-puma")
-
-          if gemfile.include?("group :development do")
-            fs.inject_line_at_block_bottom "Gemfile", "group :development do", <<~CODE
-              gem "guard-puma"
-            CODE
-          else
-            fs.append "Gemfile", <<~CODE
-
-              group :development do
-                gem "guard-puma", "~> 0.8"
-              end
-            CODE
-          end
-
-          bundler.install!
         end
       end
 

--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -4,14 +4,12 @@ require "tmpdir"
 
 RSpec.describe Hanami::Reloader::Commands::Install do
   describe "#call" do
-    subject { described_class.new(fs: fs, bundler: bundler) }
+    subject { described_class.new(fs: fs) }
 
     let(:fs) { Dry::Files.new }
     let(:dir) { Dir.mktmpdir }
     let(:app) { "synth" }
     let(:app_name) { "Synth" }
-
-    let(:bundler) { instance_spy(Hanami::CLI::Bundler) }
 
     let(:arbitrary_argument) { {} }
 
@@ -23,14 +21,6 @@ RSpec.describe Hanami::Reloader::Commands::Install do
 
     it "generates configurations" do
       subject.call(arbitrary_argument)
-
-      # Gemfile
-      gemfile = <<~EOF
-        group :development do
-          gem "guard-puma", "~> 0.8"
-        end
-      EOF
-      expect(fs.read("Gemfile")).to include(gemfile)
 
       # Guardfile
       matcher = Hanami::Reloader::Commands::Install::MATCHER.inspect.gsub("/^", "^").gsub("$/i", "$}i").gsub('*\\.', "*.").gsub("\\\\\\", %(\\))
@@ -47,11 +37,6 @@ RSpec.describe Hanami::Reloader::Commands::Install do
         end
       EOF
       expect(fs.read("Guardfile")).to eq(guardfile)
-    end
-
-    it "runs bundle install" do
-      subject.call(arbitrary_argument)
-      expect(bundler).to have_received(:install!)
     end
   end
 end


### PR DESCRIPTION
Move the guard and guard-puma dependencies into the gemspec here, rather than installing the relevant lines into the app’s `Gemfile`.

This achieves two things:

- It makes the app `Gemfile` a little cleaner. hanami-reloader is already there, so we don’t really need the extra lines.
- It allows us to exercise greater control over the guard versions we use. In this change we’re requiring a version that addresses warnings that began to appear on Ruby 3.3.5. We want to ensuire our users don’t see those warnings.

We already have a couple of hanami gems act as the place where we manage dependencies (hanami-validations, hanami-webconsole), so this change makes hanami-reloader consistent with those.

Resolves #29, relates to https://github.com/hanami/hanami/issues/1454