### PR TITLE
Add Ruby 3.4 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"


### PR DESCRIPTION
Draft until https://github.com/hanami/devtools/pull/89 is merged, then CI _should_ pass for 3.4