### PR TITLE
Add workaround for RDoc causing JRuby failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,12 @@ gem "hanami", github: "hanami/hanami", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
+# Work around RDoc/JRuby incompatibiltiy: rdoc 8 depends on rbs 4, whose native C extension can't
+# build on JRuby.
+#
+# Remove this once https://github.com/ruby/rdoc/issues/1746 is resolved.
+gem "rdoc", "< 8.0"
+
 group :test do
   gem "rspec", "~> 3.7"
 end


### PR DESCRIPTION
RDoc 8 depends on rbs 4, whose native C extension can't build on JRuby.

We can remove this once https://github.com/ruby/rdoc/issues/1746 is resolved.